### PR TITLE
Fix forbidden Origin header when fetching snapshots

### DIFF
--- a/flashback.html
+++ b/flashback.html
@@ -221,13 +221,9 @@
         // Updated Archive.org service
         const archive = {
             async getSnapshots(url) {
-                const headers = new Headers({
-                    'Origin': window.location.origin
-                });
-
                 const cdxUrl = `https://web.archive.org/cdx/search/cdx?url=${encodeURIComponent(url)}&output=json&fl=timestamp,original,statuscode&filter=statuscode:200&collapse=timestamp:8`;
-                
-                const response = await fetch(cdxUrl, { headers, mode: 'cors' });
+
+                const response = await fetch(cdxUrl, { mode: 'cors' });
 
                 if (!response.ok) {
                     throw new Error('Failed to fetch snapshots');


### PR DESCRIPTION
## Summary
- remove the manually-set Origin header from CDX snapshot requests to avoid forbidden header errors in browsers

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d03c645bb0832a8058ad2640ac94b5